### PR TITLE
Feature/database

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 #### Installation
 
 ```ssh
-composer require reinvanoyen/oak-wishlist
+composer require tallieutallieu/oak-wishlist
 ```
 
 #### Example usage

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "reinvanoyen/oak-wishlist",
+  "name": "tallieutallieu/oak-wishlist",
   "description": "Wishlist for Oak",
   "keywords": ["fav", "list", "favorites", "wishlist", "oak"],
   "type": "library",
@@ -10,8 +10,8 @@
     }
   ],
   "require": {
-    "reinvanoyen/oak": "^1.0.0",
-    "reinvanoyen/dry-internal-api": "^1.0.0"
+    "tallieutallieu/oak": "^1.0.0",
+    "tallieutallieu/dry-internal-api": "^1.0.0"
   },
   "autoload": {
     "psr-4": {

--- a/config/wishlist.php
+++ b/config/wishlist.php
@@ -3,23 +3,13 @@
 return [
     /*
     |--------------------------------------------------------------------------
-    | Wishlist Storage
+    | Wishlist Driver
     |--------------------------------------------------------------------------
     |
     | Possible options: session, database
     |
     */
-    'storage' => 'database',
-
-    /*
-    |--------------------------------------------------------------------------
-    | Wishlist Table
-    |--------------------------------------------------------------------------
-    |
-    | Provide a different table name if needed.
-    |
-    */
-    'table' => 'wishlist',
+    'driver' => 'database',
 
     /*
     |--------------------------------------------------------------------------
@@ -30,5 +20,18 @@ return [
     | Only available when using database storage.
     |
     */
-    'model' => Tnt\Wishlist\Model\Wishlist::class
+    'model' => Tnt\Wishlist\Model\Wishlist::class,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Wishlist Identifier
+    |--------------------------------------------------------------------------
+    |
+    | When the database option is selected, we need an identifier to attach the
+    | Wishlist items to.
+    |
+    | You can specify the Model that implements WishlistableInterface here.
+    |
+    */
+    'identifier' => app\model\User::class,
 ];

--- a/config/wishlist.php
+++ b/config/wishlist.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Wishlist Storage
+    |--------------------------------------------------------------------------
+    |
+    | Possible options: session, database
+    |
+    */
+    'storage' => 'database',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Wishlist Table
+    |--------------------------------------------------------------------------
+    |
+    | Provide a different table name if needed.
+    |
+    */
+    'table' => 'wishlist',
+
+    /*
+    |--------------------------------------------------------------------------
+    | Wishlist Model
+    |--------------------------------------------------------------------------
+    |
+    | This option allows for the extension of the wishlist Model.
+    | Only available when using database storage.
+    |
+    */
+    'model' => Tnt\Wishlist\Model\Wishlist::class
+];

--- a/src/Admin/WishlistManager.php
+++ b/src/Admin/WishlistManager.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tnt\Wishlist\Admin;
+
+use dry\admin\Module;
+use dry\orm\Manager;
+
+class WishlistManager extends Manager
+{
+    public function __construct()
+    {
+        // TODO: inject config model
+        $model = null;
+
+        parent::__construct($model, [
+            'icon' => Module::ICON_GENRE,
+            'singular' => 'Wishlist',
+            'plural' => 'Wishlist',
+        ]);
+
+        // TODO: create
+        // TODO: edit
+        // TODO: delete
+        // TODO: paginator
+        // TODO: sorter
+        // TODO: filter
+    }
+}

--- a/src/Contracts/WishlistInterface.php
+++ b/src/Contracts/WishlistInterface.php
@@ -37,7 +37,7 @@ interface WishlistInterface
 	 *
 	 * @return void
 	 */
-	public function clear();
+	public function clear(): void;
 
 	/**
 	 * Gets all items

--- a/src/Contracts/WishlistableInterface.php
+++ b/src/Contracts/WishlistableInterface.php
@@ -4,5 +4,5 @@ namespace Tnt\Wishlist\Contracts;
 
 interface WishlistableInterface
 {
-    public function getIdentifier(): int;
+    public function getWishlistIdentifier(): int;
 }

--- a/src/Contracts/WishlistableInterface.php
+++ b/src/Contracts/WishlistableInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tnt\Wishlist\Contracts;
+
+interface WishlistableInterface
+{
+    public function getIdentifier(): int;
+}

--- a/src/DatabaseWishlist.php
+++ b/src/DatabaseWishlist.php
@@ -4,6 +4,7 @@ namespace Tnt\Wishlist;
 
 use dry\db\FetchException;
 use dry\Debug;
+use Tnt\Wishlist\Contracts\WishlistableInterface;
 use Tnt\Wishlist\Contracts\WishlistInterface;
 use Tnt\Wishlist\Contracts\WishlistItemInterface;
 
@@ -15,12 +16,12 @@ class DatabaseWishlist implements WishlistInterface
 
     private $items = [];
 
-    public function __construct(string $model, $identifier)
+    public function __construct(WishlistableInterface $wishlistable, string $model)
     {
         $this->model = $model;
-        $this->identifier = $identifier;
+        $this->identifier = $wishlistable->getWishlistIdentifier();
 
-        Debug::log($identifier, $identifier);
+        Debug::log($wishlistable->getWishlistIdentifier(), $wishlistable->getWishlistIdentifier());
 
         $this->restore();
     }

--- a/src/DatabaseWishlist.php
+++ b/src/DatabaseWishlist.php
@@ -1,0 +1,163 @@
+<?php
+
+namespace Tnt\Wishlist;
+
+use dry\db\FetchException;
+use dry\Debug;
+use Tnt\Wishlist\Contracts\WishlistInterface;
+use Tnt\Wishlist\Contracts\WishlistItemInterface;
+
+class DatabaseWishlist implements WishlistInterface
+{
+    public $model;
+
+    private $identifier;
+
+    private $items = [];
+
+    public function __construct(string $model, $identifier)
+    {
+        $this->model = $model;
+        $this->identifier = $identifier;
+
+        Debug::log($identifier, $identifier);
+
+        $this->restore();
+    }
+
+    public function add(WishlistItemInterface $item)
+    {
+        $classname = get_class($item);
+
+        if ($this->has($item)) {
+            return;
+        }
+
+        if (!isset($this->items[$classname])) {
+            $this->items[$classname] = [];
+        }
+
+        $this->items[$classname][] = $item->getWishlistId();
+
+        $this->save();
+    }
+
+    public function remove(WishlistItemInterface $item)
+    {
+        $classname = get_class($item);
+
+        if (! $this->has($item)) {
+            return;
+        }
+
+        $classNameArray =& $this->items[$classname];
+
+        unset($classNameArray[array_search($item->getWishlistId(), $classNameArray)]);
+
+        $this->save();
+    }
+
+    public function has(WishlistItemInterface $item): bool
+    {
+        $classname = get_class($item);
+
+        return isset($this->items[$classname]) && in_array($item->getWishlistId(), $this->items[$classname]);
+    }
+
+    public function clear(): void
+    {
+        $this->items = [];
+
+        $this->save();
+    }
+
+    public function getItems(): array
+    {
+        $items = [];
+
+        foreach ($this->items as $classname => $ids) {
+
+            if (! class_exists($classname)) {
+                continue;
+            }
+
+            foreach ($ids as $id) {
+                $item = $classname::getByWishlistId($id);
+
+                if (! $item) {
+                    continue;
+                }
+
+                $items[] = $item;
+            }
+        }
+
+        return $items;
+    }
+
+    private function restore()
+    {
+        $items = $this->model::all('WHERE identifier = ?', $this->identifier);
+
+        foreach ($items as $item) {
+            $class = $item->wishlist_class;
+            $id = $item->wishlist_id;
+
+            $item = $class::getByWishlistId($id);
+
+            if (! $item) {
+                continue;
+            }
+
+            $this->items[$class][] = $id;
+        }
+    }
+
+    private function save()
+    {
+        $items = $this->items;
+        $identifier = $this->identifier;
+
+        $saveIds = [];
+
+        foreach ($items as $class => $groupedIds) {
+            foreach ($groupedIds as $id) {
+                $item = null;
+
+                try {
+                    $item = $this->model::load_by([
+                        'wishlist_class' => $class,
+                        'wishlist_id' =>  $id,
+                        'identifier' => $identifier
+                    ]);
+                }
+                catch (FetchException $exception) {
+                    $item = new $this->model();
+                    $item->created = time();
+                    $item->updated = time();
+                    $item->wishlist_class = $class;
+                    $item->wishlist_id = $id;
+                    $item->identifier = $identifier;
+                    $item->save();
+                }
+
+                $saveIds[] = $item->id;
+            }
+        }
+
+        if (count($saveIds)) {
+            $itemsToDelete = $this->model::all('
+                WHERE id NOT IN (' . implode(',', $saveIds) . ')
+                AND identifier = ?
+            ', $identifier);
+        }
+
+        else {
+            $itemsToDelete = $this->model::all('WHERE identifier = ?', $identifier);
+        }
+
+        foreach ($itemsToDelete as $item) {
+            $item->delete();
+        }
+    }
+}

--- a/src/Exception/InvalidIdentifierException.php
+++ b/src/Exception/InvalidIdentifierException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Tnt\Wishlist\Exception;
+
+class InvalidIdentifierException extends \Exception
+{
+    //
+}

--- a/src/Model/Wishlist.php
+++ b/src/Model/Wishlist.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Tnt\Wishlist\Model;
+
+use dry\orm\Model;
+
+class Wishlist extends Model
+{
+    const TABLE = 'wishlist';
+}

--- a/src/Revisions/CreateWishlistTable.php
+++ b/src/Revisions/CreateWishlistTable.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Tnt\Wishlist\Revisions;
+
+use app\revisions\DatabaseRevision;
+use Oak\Contracts\Migration\RevisionInterface;
+use Tnt\Dbi\TableBuilder;
+
+class CreateWishlistTable extends DatabaseRevision implements RevisionInterface
+{
+    public function up()
+    {
+        $this->queryBuilder->table('wishlist')->create(function(TableBuilder $table) {
+            $table->addColumn('id', 'int')->length(11)->primaryKey();
+            $table->addColumn('created', 'int')->length(11);
+            $table->addColumn('updated', 'int')->length(11);
+
+            $table->addColumn('wishlist_class', 'varchar')->length(255);
+            $table->addColumn('wishlist_id', 'int')->length(11);
+
+            $table->addColumn('identifier', 'int')->length(11)->null();
+        });
+
+        $this->execute();
+    }
+
+    public function down()
+    {
+        $this->queryBuilder->table('wishlist')->drop();
+
+        $this->execute();
+    }
+
+    public function describeUp(): string
+    {
+        return 'Table wishlist created';
+    }
+
+    public function describeDown(): string
+    {
+        return 'Table wishlist dropped';
+    }
+}

--- a/src/Revisions/DatabaseRevision.php
+++ b/src/Revisions/DatabaseRevision.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tnt\Faq\Revisions;
+
+use dry\db\Connection;
+use Tnt\Dbi\QueryBuilder;
+
+/**
+ * Class DatabaseRevision
+ * @package Tnt\Ecommerce
+ */
+abstract class DatabaseRevision
+{
+    /**
+     * @var QueryBuilder $queryBuilder
+     */
+    protected $queryBuilder;
+
+    /**
+     * DatabaseRevision constructor.
+     *
+     * @param QueryBuilder $queryBuilder
+     */
+    public function __construct(QueryBuilder $queryBuilder)
+    {
+        $this->queryBuilder = $queryBuilder;
+    }
+
+    protected function execute()
+    {
+        $this->queryBuilder->build();
+
+        Connection::get()->query($this->queryBuilder->getQuery());
+    }
+}

--- a/src/SessionWishlist.php
+++ b/src/SessionWishlist.php
@@ -72,7 +72,7 @@ class SessionWishlist implements WishlistInterface
 	/**
 	 * @return void
 	 */
-	public function clear()
+	public function clear(): void
 	{
 		$this->items = [];
 		$this->save();

--- a/src/WishlistServiceProvider.php
+++ b/src/WishlistServiceProvider.php
@@ -8,7 +8,9 @@ use Oak\Migration\MigrationManager;
 use Oak\Migration\Migrator;
 use Oak\ServiceProvider;
 use Tnt\Account\Facade\Auth;
+use Tnt\Account\SessionUserStorage;
 use Tnt\InternalApi\Facade\Api;
+use Tnt\Wishlist\Contracts\WishlistableInterface;
 use Tnt\Wishlist\Contracts\WishlistInterface;
 use Tnt\Wishlist\Exception\InvalidIdentifierException;
 use Tnt\Wishlist\Revisions\CreateWishlistTable;
@@ -40,21 +42,24 @@ class WishlistServiceProvider extends ServiceProvider
 	{
         $config = $app->get(RepositoryInterface::class);
 
-        if ($config->get('wishlist.storage') === 'session') {
+        if ($config->get('wishlist.driver') === 'session') {
 		    $app->singleton(WishlistInterface::class, SessionWishlist::class);
         }
 
-        if ($config->get('wishlist.storage') === 'database') {
+        if ($config->get('wishlist.driver') === 'database') {
             $model = $config->get('wishlist.model', Model\Wishlist::class);
-            $identifier = $config->get('wishlist.identifier');
+            $wishlistable = $config->get('wishlist.identifier');
 
-            if (!$identifier) {
+            if (!$wishlistable) {
                 throw new InvalidIdentifierException();
             }
 
             $app->singleton(WishlistInterface::class, DatabaseWishlist::class);
+
+            $app->set(WishlistableInterface::class, $wishlistable);
+
             $app->whenAsksGive(DatabaseWishlist::class, 'model', $model);
-            $app->whenAsksGive(DatabaseWishlist::class, 'identifier', $identifier);
+            //$app->whenAsksGive(DatabaseWishlist::class, 'identifier', $identifier);
         }
 	}
 }

--- a/src/WishlistServiceProvider.php
+++ b/src/WishlistServiceProvider.php
@@ -2,10 +2,16 @@
 
 namespace Tnt\Wishlist;
 
+use Oak\Contracts\Config\RepositoryInterface;
 use Oak\Contracts\Container\ContainerInterface;
+use Oak\Migration\MigrationManager;
+use Oak\Migration\Migrator;
 use Oak\ServiceProvider;
+use Tnt\Account\Facade\Auth;
 use Tnt\InternalApi\Facade\Api;
 use Tnt\Wishlist\Contracts\WishlistInterface;
+use Tnt\Wishlist\Exception\InvalidIdentifierException;
+use Tnt\Wishlist\Revisions\CreateWishlistTable;
 
 class WishlistServiceProvider extends ServiceProvider
 {
@@ -16,10 +22,39 @@ class WishlistServiceProvider extends ServiceProvider
 		Api::get('wishlist/add/', '\\Tnt\\Wishlist\\Controller\\ApiController::add');
 		Api::get('wishlist/remove/', '\\Tnt\\Wishlist\\Controller\\ApiController::remove');
 		Api::get('wishlist/clear/', '\\Tnt\\Wishlist\\Controller\\ApiController::clear');
+
+        if ($app->isRunningInConsole()) {
+            $migrator = $app->getWith(Migrator::class, [
+                'name' => 'wishlist'
+            ]);
+
+            $migrator->setRevisions([
+                CreateWishlistTable::class,
+            ]);
+
+            $app->get(MigrationManager::class)->addMigrator($migrator);
+        }
 	}
 
 	public function register(ContainerInterface $app)
 	{
-		$app->singleton(WishlistInterface::class, SessionWishlist::class);
+        $config = $app->get(RepositoryInterface::class);
+
+        if ($config->get('wishlist.storage') === 'session') {
+		    $app->singleton(WishlistInterface::class, SessionWishlist::class);
+        }
+
+        if ($config->get('wishlist.storage') === 'database') {
+            $model = $config->get('wishlist.model', Model\Wishlist::class);
+            $identifier = $config->get('wishlist.identifier');
+
+            if (!$identifier) {
+                throw new InvalidIdentifierException();
+            }
+
+            $app->singleton(WishlistInterface::class, DatabaseWishlist::class);
+            $app->whenAsksGive(DatabaseWishlist::class, 'model', $model);
+            $app->whenAsksGive(DatabaseWishlist::class, 'identifier', $identifier);
+        }
 	}
 }


### PR DESCRIPTION
Added the possibility to switch between a drivers: `session` and `database`. 

**Changes**

config/wishlist.php

``` php
<?php

return [
    /*
    |--------------------------------------------------------------------------
    | Wishlist Driver
    |--------------------------------------------------------------------------
    |
    | Possible options: session, database
    |
    */
    'driver' => 'database',

    /*
    |--------------------------------------------------------------------------
    | Wishlist Model
    |--------------------------------------------------------------------------
    |
    | This option allows for the extension of the wishlist Model.
    | Only available when using database storage.
    |
    */
    'model' => Tnt\Wishlist\Model\Wishlist::class,

    /*
    |--------------------------------------------------------------------------
    | Wishlist Identifier
    |--------------------------------------------------------------------------
    |
    | When the database option is selected, we need an identifier to attach the
    | Wishlist items to.
    |
    | You can specify the Model that implements WishlistableInterface here.
    |
    */
    'identifier' => app\model\User::class,
];
```